### PR TITLE
refactor: streamline slice handling across adapters

### DIFF
--- a/anthropic.go
+++ b/anthropic.go
@@ -55,7 +55,7 @@ func MessagesToAnthropic(messages []Message) ([]anthropic.MessageParam, []anthro
 
 	for _, message := range messages {
 		role := anthropic.MessageParamRoleAssistant
-		content := []anthropic.ContentBlockParamUnion{}
+		var content []anthropic.ContentBlockParamUnion
 
 		switch message.Role {
 		case "system":
@@ -106,7 +106,7 @@ func MessagesToAnthropic(messages []Message) ([]anthropic.MessageParam, []anthro
 					})
 					content = nil
 
-					resultContent := []anthropic.ToolResultBlockParamContentUnion{}
+					var resultContent []anthropic.ToolResultBlockParamContentUnion
 					resultParts, err := toolResultToParts(part.ToolInvocation.Result)
 					if err != nil {
 						return nil, nil, fmt.Errorf("failed to convert tool call result to parts: %w", err)
@@ -207,13 +207,15 @@ func MessagesToAnthropic(messages []Message) ([]anthropic.MessageParam, []anthro
 // AnthropicToDataStream pipes an Anthropic stream to a DataStream.
 func AnthropicToDataStream(stream *ssestream.Stream[anthropic.MessageStreamEventUnion]) DataStream {
 	return func(yield func(DataStreamPart, error) bool) {
-		var lastChunk *anthropic.MessageStreamEventUnion
-		var finalReason FinishReason = FinishReasonUnknown
-		var finalUsage Usage
-		var currentToolCall struct {
-			ID   string
-			Args string
-		}
+		var (
+			lastChunk       *anthropic.MessageStreamEventUnion
+			finalReason     = FinishReasonUnknown
+			finalUsage      Usage
+			currentToolCall struct {
+				ID   string
+				Args string
+			}
+		)
 
 		for stream.Next() {
 			chunk := stream.Current()

--- a/google.go
+++ b/google.go
@@ -18,7 +18,7 @@ type GoogleStreamIterator interface {
 }
 
 func ToolsToGoogle(tools []Tool) ([]*genai.Tool, error) {
-	functionDeclarations := []*genai.FunctionDeclaration{}
+	functionDeclarations := make([]*genai.FunctionDeclaration, 0, len(tools))
 
 	var propertyToSchema func(property map[string]any) (*genai.Schema, error)
 	propertyToSchema = func(property map[string]any) (*genai.Schema, error) {

--- a/openai.go
+++ b/openai.go
@@ -12,7 +12,7 @@ import (
 
 // ToolsToOpenAI converts the tool format to OpenAI's API format.
 func ToolsToOpenAI(tools []Tool) []openai.ChatCompletionToolParam {
-	openaiTools := []openai.ChatCompletionToolParam{}
+	openaiTools := make([]openai.ChatCompletionToolParam, len(tools))
 	for _, tool := range tools {
 		var schemaParams map[string]any
 		if tool.Schema.Properties != nil {

--- a/stream.go
+++ b/stream.go
@@ -470,7 +470,7 @@ type Part struct {
 
 	// Type: "step-start" - No additional fields
 
-	isComplete bool `json:"-"` // Internal accumulator tracking
+	isComplete bool // Internal accumulator tracking
 }
 
 type Tool struct {


### PR DESCRIPTION
  - rely on zero-value slices in the Anthropic adapter and drop the redundant break
  - pre-size Google/OpenAI tool declarations and reuse tool-result buffers
  - remove the unused json tag from the internal stream completion flag